### PR TITLE
Add deltas

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -1,6 +1,7 @@
 module Lib
     ( fit
     , fitF
+    , deltas
     , hello
     , FitMode(..)
     )
@@ -38,6 +39,24 @@ fitF maps the fit function over Functors of Integrals.
 -}
 fitF :: (Functor f, Integral a) => FitMode -> a -> a -> f a -> f a
 fitF mode min max = fmap (fit mode min max)
+
+{-|
+deltas returns list of differences between adjacent numbers in the input list. As such, the resulting list 
+will be one element shorter than the input list. 
+
+Example: 
+
+In:  [3, 2, 1] 
+Out: [1, 1]
+
+NOTE: This can be made generic for container types other than list but need to look into that.
+-}
+deltas :: (Integral a) => [a] -> [a]
+deltas []         = []
+deltas [  x     ] = [x]
+deltas l@(_ : xs) = zipWith (-) l xs
+
+
 
 hello :: IO ()
 hello = putStrLn "Welcome to Mu, an algorithmic composition toolbox."

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -2,6 +2,7 @@ import           Test.Hspec
 import qualified Lib                            ( FitMode(..)
                                                 , fit
                                                 , fitF
+                                                , deltas
                                                 )
 
 
@@ -9,6 +10,7 @@ main :: IO ()
 main = do
     testFit
     testFitF
+    testDeltas
 
 testFit :: IO ()
 testFit = hspec $ describe "fit" $ do
@@ -50,6 +52,18 @@ testFitF = hspec $ describe "fitF" $ do
     it "returns n in a Just when n is between min and max and mode is Wrap"
         $          Lib.fitF Lib.Wrap 1 3 (Just 2)
         `shouldBe` Just 2
+
+
+testDeltas :: IO ()
+testDeltas = hspec $ describe "deltas" $ do
+    it "returns list of differences between adjacent numbers in the input list"
+        $          Lib.deltas [5, 1, 4, 2, 3]
+        `shouldBe` [4, -3, 2, -1]
+
+    it "returns a list one element shorter than the input list"
+        $          length (Lib.deltas [3, 2, 1])
+        `shouldBe` length [3, 2, 1]
+        -          1
 
 
 


### PR DESCRIPTION
Add the deltas function and tests. This function returns the difference
between adjacent numbers in a list.

A few examples: 

In:    [3, 2, 1]
Out: [1, 1] 

In:    [5, 1, 4, 2, 3] 
Out: [4, -3, 2, -1]

NOTE: 

This function really should be generic for any `*->*` container type. I am looking at http://hackage.haskell.org/package/emgm-0.3/docs/Generics-EMGM-Functions-ZipWith.html

but it is listed as experimental and unstable at the moment. 