### PR TITLE
Add quantization function.

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -3,7 +3,9 @@ module Lib
     , fitF
     , deltas
     , hello
+    , uniformQuantize
     , FitMode(..)
+    , UniformMode(..)
     )
 where
 
@@ -35,7 +37,7 @@ fit mode min max n = if inRange
 
 
 {-|
-fitF maps the fit function over Functors of Integrals. 
+fitF maps the fit function over functors. 
 -}
 fitF :: (Functor f, Integral a) => FitMode -> a -> a -> f a -> f a
 fitF mode min max = fmap (fit mode min max)
@@ -55,6 +57,42 @@ deltas :: (Integral a) => [a] -> [a]
 deltas []         = []
 deltas [  x     ] = [x]
 deltas l@(_ : xs) = zipWith (-) l xs
+
+
+{-|
+QuantizeMode 
+
+MidTread 
+MidRiser
+-}
+data UniformMode
+    = MidTread
+    | MidRiser
+    deriving (Show)
+
+{-|
+uniformQuantize transforms a Real number to the closest multiple of step. There are two modes: 
+
+MidTread uses the following algorithm: 
+    step * floor((n / step) + 0.5)
+
+MidRiser uses the following algorithm: 
+    step * (floor(n / step)) + 0.5
+-}
+uniformQuantize :: (RealFrac a) => UniformMode -> a -> a -> a
+uniformQuantize mode step n = case mode of
+    MidTread -> step * midTreadClassificationStage
+    MidRiser -> step * (midRiserClassificationStage + 0.5)
+  where
+    midTreadClassificationStage = conv ((n / step) + 0.5)
+    midRiserClassificationStage = conv (n / step)
+    conv                        = fromIntegral . floor
+
+{-
+uniformQuantizeF maps the uniformQuantize function over functors. 
+-}
+uniformQuantizeF :: (Functor f, RealFrac a) => UniformMode -> a -> f a -> f a
+uniformQuantizeF mode step = fmap (uniformQuantize mode step)
 
 
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,8 +1,10 @@
 import           Test.Hspec
 import qualified Lib                            ( FitMode(..)
+                                                , UniformMode(..)
                                                 , fit
                                                 , fitF
                                                 , deltas
+                                                , uniformQuantize
                                                 )
 
 
@@ -11,6 +13,7 @@ main = do
     testFit
     testFitF
     testDeltas
+    testUniformQuantize
 
 testFit :: IO ()
 testFit = hspec $ describe "fit" $ do
@@ -64,6 +67,13 @@ testDeltas = hspec $ describe "deltas" $ do
         $          length (Lib.deltas [3, 2, 1])
         `shouldBe` length [3, 2, 1]
         -          1
+
+
+testUniformQuantize :: IO ()
+testUniformQuantize = hspec $ describe "uniformQuantize" $ do
+    it "quantizes n to the closest multiple of step"
+        $          Lib.uniformQuantize Lib.MidTread 2 13.0
+        `shouldBe` 14.0
 
 
 


### PR DESCRIPTION
This adds a uniform quantization function with mid-tread and mid-rise modes. 

Mid-Tread uses the following algorithm:
<img width="346" alt="Screen Shot 2019-12-02 at 12 29 01 AM" src="https://user-images.githubusercontent.com/3971338/69932874-c45a6900-149a-11ea-862c-b1f1f9d6b26c.png">

Mid-Rise uses the following algorithm:
<img width="208" alt="Screen Shot 2019-12-02 at 12 30 06 AM" src="https://user-images.githubusercontent.com/3971338/69932926-ea800900-149a-11ea-90fa-6d56247bd21c.png">